### PR TITLE
Ability to produce a coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ module.exports = function (config) {
 * *String[] | Object[]* `sourceLevels` &mdash;&nbsp;уровни, в&nbsp;которых следует искать код шаблонов, необходимый для шаблонизации эталонных BEMJSON-файлов.
 * *String[]* `referenceDirSuffixes` &mdash;&nbsp;суффиксы папок технологий с&nbsp;эталонами. По&nbsp;умолчанию&nbsp;&mdash;&nbsp;`['tmpl-specs']`.
 * *Object* `engines` &mdash;&nbsp; опция определяет какие ENB-технологии следует использовать для сборки шаблонов. Обязательная опция.
+* Boolean `coverage` &mdash;&nbsp; включает генерацию отчета о покрытии кода шаблонов тестами. Код шаблонов должен
+был бы предварительно инструментирован при помощи [`istanbul`](https://github.com/gotwarlost/istanbul).
+* String[] `coverageVars` &mdash;&nbsp; имена переменных, в которые `istanbul` сохраняет данные о покрытии.
+* String[] `coverageReporters` &mdash;&nbsp; имена репортеров для отчета о покрытии. Также можно задать через
+переменную окружения `BEM_TMPL_SPECS_COV_REPORTERS`.
 
 Запуск из консоли
 -----------------

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -59,6 +59,13 @@ module.exports = function (helper) {
                 }),
                 sourceLevels: options.sourceLevels || options.levels,
                 referenceDirSuffixes: options.referenceDirSuffixes || ['tmpl-specs'],
+                coverage: options.coverage || false,
+                coverageVars: options.coverageVars || [],
+                coverageReporters: options.coverageReporters || (
+                    process.env.BEM_TMPL_SPECS_COV_REPORTERS ?
+                    process.env.BEM_TMPL_SPECS_COV_REPORTERS.split(',')
+                    : ['html']),
+
                 saveHtml: (typeof process.env.BEM_TMPL_SPECS_SAVE_HTML === 'undefined' ?
                     options.saveHtml :
                     process.env.BEM_TMPL_SPECS_SAVE_HTML) || false
@@ -142,7 +149,7 @@ module.exports = function (helper) {
                     return path.join(options.root, node, basename + '.tmpl-spec.js');
                 });
 
-                return filesToRun.length && runner.run(filesToRun)
+                return filesToRun.length && runner.run(filesToRun, options)
                     .fail(function (err) {
                         if (err.stack) {
                             console.error(err.stack);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,7 +1,8 @@
 var vow = require('vow'),
-    Mocha = require('mocha');
+    Mocha = require('mocha'),
+    istanbul = require('istanbul');
 
-exports.run = function (files) {
+exports.run = function (files, opts) {
     var defer = vow.defer(),
         mocha = new Mocha({
             ui: 'bdd',
@@ -10,7 +11,15 @@ exports.run = function (files) {
 
     mocha.files = files;
     mocha.run(function (failures) {
-        failures ? defer.reject(failures) : defer.resolve();
+        function resolvePromise() {
+            failures ? defer.reject(failures) : defer.resolve();
+        }
+
+        if (opts.coverage) {
+            processCoverage(opts).done(resolvePromise);
+        } else {
+            resolvePromise();
+        }
 
         process.on('exit', function () {
             process.exit(failures);
@@ -19,6 +28,21 @@ exports.run = function (files) {
 
     return defer.promise();
 };
+
+function processCoverage(opts) {
+    var defer = vow.defer(),
+        collector = new istanbul.Collector(),
+        reporter = new istanbul.Reporter(null, 'tmpl-coverage');
+    opts.coverageVars.forEach(function (varName) {
+        collector.add(global[varName]);
+    });
+    reporter.addAll(opts.coverageReporters);
+    reporter.write(collector, false, function () {
+        defer.resolve();
+    });
+
+    return defer.promise();
+}
 
 // Helper allow you to run the multiple reporters
 function runReporters(runner) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "html-differ": "1.0.3",
     "vow": "0.4.6",
     "inherit": "2.2.2",
+    "istanbul": "0.3.2",
     "mocha": "1.21.5",
     "lodash": "2.4.1",
     "js-beautify": "1.5.4",


### PR DESCRIPTION
Templates should be pre-instrumented before enabling the flag.
For now, only `bh` has tech that can do this.
Reports will be saved to `tmpl-coverage` dir to avoid clash
with normal code coverage.

Counterpart to enb-bem/enb-bh#38

@andrewblond @arikon @scf2k 
