### PR TITLE
Make possible to build tmpl-spec bundle containing all project templates

### DIFF
--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -4,6 +4,7 @@ var path = require('path'),
     _ = require('lodash'),
 
     levels = require('enb-bem-techs/techs/levels'),
+    levelsToBemdecl = require('enb-bem-techs/techs/levels-to-bemdecl'),
     files = require('enb-bem-techs/techs/files'),
 
     provide = require('enb/techs/file-provider'),
@@ -23,7 +24,8 @@ var path = require('path'),
 
 exports.configure = function (config, options) {
     var pattern = path.join(options.destPath, '*'),
-        sourceLevels = [].concat(options.sourceLevels);
+        sourceLevels = [].concat(options.sourceLevels),
+        coverageRe = new RegExp('/' + options.coverage.completeBundle + '$');
 
     config.nodes(pattern, function (nodeConfig) {
         var nodePath = nodeConfig.getNodePath(),
@@ -37,10 +39,14 @@ exports.configure = function (config, options) {
             sourceLevels.push(sublevel);
         }
 
+        var isCoverageBundle = coverageRe.test(nodeConfig.getPath());
+
         // Base techs
         nodeConfig.addTechs([
             [levels, { levels: sourceLevels }],
-            [provide, { target: '?.base.bemdecl.js' }],
+            [isCoverageBundle ? levelsToBemdecl : provide, {
+                target: '?.base.bemdecl.js'
+            }],
             [depsByTechToBemdecl, {
                 target: '?.tech.bemdecl.js',
                 filesTarget: '?.base.files',
@@ -152,7 +158,8 @@ exports.configure = function (config, options) {
                 langs: langs,
                 engineTargets: engineTargets,
                 saveHtml: options.saveHtml,
-                coverageEngines: coverageEngines
+                coverageEngines: coverageEngines,
+                coverageBundle: isCoverageBundle
             }]
         ]);
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -75,9 +75,9 @@ module.exports = function (helper) {
                     ],
                     reporters: process.env.BEM_TMPL_SPECS_COV_REPORTERS ?
                         process.env.BEM_TMPL_SPECS_COV_REPORTERS.split(',')
-                        : ['lcov']
+                        : ['lcov'],
+                    completeBundle: ''
                 }),
-
                 referenceDirSuffixes: options.referenceDirSuffixes || ['tmpl-specs'],
                 saveHtml: (typeof process.env.BEM_TMPL_SPECS_SAVE_HTML === 'undefined' ?
                     options.saveHtml :
@@ -90,33 +90,49 @@ module.exports = function (helper) {
                 dstpath = path.resolve(options.root, options.destPath);
 
             helper.prebuild(function (magic) {
-                return scanner.scan(options.levels)
-                    .then(function (files) {
-                        var nodes = {},
-                            nodesToRun = {};
+                var completeBundleDirname;
+                if (options.coverage.engines.length && options.coverage.completeBundle) {
+                    completeBundleDirname = path.join(options.destPath, options.coverage.completeBundle);
+                    magic.registerNode(completeBundleDirname);
+                }
 
-                        files.forEach(function (file) {
-                            if (options.referenceDirSuffixes.indexOf(file.suffix) !== -1) {
-                                var bemname = file.name.split('.')[0],
-                                    node = path.join(options.destPath, bemname),
-                                    mainTarget = path.join(node, bemname + '.tmpl-spec.js');
+                return vow.all([
+                    completeBundleDirname && vfs.makeDir(path.join(options.root, completeBundleDirname)),
+                    scanner.scan(options.levels)
+                        .then(function (files) {
+                            var nodes = {},
+                                nodesToRun = {};
 
-                                if (magic.isRequiredNode(node)) {
-                                    nodes[node] = true;
-                                    magic.registerNode(node);
+                            files.forEach(function (file) {
+                                if (options.referenceDirSuffixes.indexOf(file.suffix) !== -1) {
+                                    var bemname = file.name.split('.')[0],
+                                        node = path.join(options.destPath, bemname),
+                                        mainTarget = path.join(node, bemname + '.tmpl-spec.js');
 
-                                    magic.isRequiredTarget(mainTarget) && (nodesToRun[node] = true);
+                                    if (magic.isRequiredNode(node)) {
+                                        nodes[node] = true;
+                                        magic.registerNode(node);
+
+                                        magic.isRequiredTarget(mainTarget) && (nodesToRun[node] = true);
+                                    }
                                 }
-                            }
-                        });
+                            });
 
-                        options.nodes = Object.keys(nodes);
-                        options.nodesToRun = Object.keys(nodesToRun);
+                            options.nodes = Object.keys(nodes);
 
-                        return vow.all(options.nodes.map(function (node) {
-                            return _this._buildBemdecl(dstpath, node);
-                        }));
-                    });
+                            var completeBundleNode = path.join(options.destPath, options.coverage.completeBundle);
+                            options.nodesToRun = Object.keys(nodesToRun)
+                                .concat(
+                                    (completeBundleDirname && magic.isRequiredNode(completeBundleNode)) ?
+                                        completeBundleNode :
+                                        []
+                                );
+
+                            return vow.all(options.nodes.map(function (node) {
+                                return _this._buildBemdecl(dstpath, node);
+                            }));
+                        })
+                ]);
             });
         },
 

--- a/lib/techs/tmpl-spec.js
+++ b/lib/techs/tmpl-spec.js
@@ -22,6 +22,7 @@ module.exports = require('enb/lib/build-flow').create()
     .defineOption('langs', [])
     .defineOption('saveHtml', false)
     .defineOption('coverageEngines', [])
+    .defineOption('coverageBundle', false)
     .useSourceFilename('references', '?.references.js')
     .needRebuild(function (cache) {
         return cache.get('saveHtml') !== this._saveHtml ||
@@ -42,27 +43,28 @@ module.exports = require('enb/lib/build-flow').create()
             coverageEngines = this._coverageEngines,
             its = {};
 
-        if (langs.length > 0) {
-            Object.keys(references).forEach(function (name) {
-                langs.forEach(function (lang) {
+        if (!this._coverageBundle) {
+            if (langs.length > 0) {
+                Object.keys(references).forEach(function (name) {
+                    langs.forEach(function (lang) {
+                        var reference = references[name],
+                            langReference = reference && reference[lang],
+                            bemjson = langReference && langReference.bemjson,
+                            html = langReference && langReference.html;
+
+                        bemjson && html && (its[name] = true);
+                    });
+                });
+            } else {
+                Object.keys(references).forEach(function (name) {
                     var reference = references[name],
-                        langReference = reference && reference[lang],
-                        bemjson = langReference && langReference.bemjson,
-                        html = langReference && langReference.html;
+                        bemjson = reference && reference.bemjson,
+                        html = reference && reference.html;
 
                     bemjson && html && (its[name] = true);
                 });
-            });
-        } else {
-            Object.keys(references).forEach(function (name) {
-                var reference = references[name],
-                    bemjson = reference && reference.bemjson,
-                    html = reference && reference.html;
-
-                bemjson && html && (its[name] = true);
-            });
+            }
         }
-
         its = Object.keys(its);
 
         return readAssets.spread(function (asset, it, iti18n) {


### PR DESCRIPTION
When coverage is enabled a special bundle (_coverageBundle by default) will be built. It will be made of all the template files from the build levels. It will not contain any tests. This makes the coverage report to contain statistics about all project templates, but not just ones that were used by the tests.
