### PR TITLE
Update html-differ

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "enb-bem-techs": "1.0.0",
     "enb-bem-i18n": "0.1.2",
     "enb-source-map": "1.5.0",
-    "html-differ": "1.0.4",
+    "html-differ": "1.0.5",
     "inherit": "2.2.2",
     "istanbul": "0.3.5",
     "jade": "1.8.2",


### PR DESCRIPTION
Там оказалось,  что я на npm положил 'левые' HTML-файлики и при загрузке они все время сваливаются в node_modules вместе с тулзой. Исправил это в 1.0.5
