### PR TITLE
Reset templates before each test

### DIFF
--- a/lib/assets/tmpl-spec.jst
+++ b/lib/assets/tmpl-spec.jst
@@ -16,35 +16,35 @@ var assert = require('assert'),
     dropRequireCache = require('enb/lib/fs/drop-require-cache'),
     HtmlDiffer = require('${ paths['html-differ'] }').HtmlDiffer,
     htmlDiffer = new HtmlDiffer('bem'),
-
-    engines = {
-        <%_.forEach(engines, function(engine, i) {
-            var exportName = engine.exportName ? '.' + engine.exportName : '',
-                sep = i === engines.length - 1 ? '' : ',\n        ';
-
-            if (langs.length) {
-                print('\'' + engine.name + '\': {\n            ');
-
-                _.forEach(langs, function(lang, i) {
-                    var sep = i === langs.length - 1 ? '' : ',\n            ',
-                        target = engine.target.replace('.js', '.' + lang + '.js');
-
-                    print('\'' + lang + '\': require(\'./' + target + '\')' + exportName + sep);
-                });
-
-                print('\n        }' + sep);
-            } else {
-                print('\'' + engine.name + '\': require(\'./' + engine.target + '\')' + exportName + sep);
-            }
-        });%>
-    },
     referencesFilename = require.resolve('${ paths.references }'),
+    engines,
     references;
 
 describe('${ describe }', function() {
     beforeEach(function () {
         dropRequireCache(require, referencesFilename);
         references = require(referencesFilename);
+
+        engines = {};
+        <% _.forEach(engines, function(engine) {
+            function reRequire(where, what) {
+                var name = what.name,
+                    target = what.target,
+                    exportName = what.exportName;
+                print('dropRequireCache(require, require.resolve(\'' + target + '\'));\n');
+                print(where + '[\'' + name + '\'] = require(\'' + target + '\')' + exportName + ';\n');
+            }
+
+            if (langs.length) {
+                var engineObject = 'engines[\'' + engine.name + '\']';
+                print(engineObject + ' = {};\n');
+                _.forEach(engine.langs, function(lang) {
+                    reRequire(engineObject, lang);
+                });
+            } else {
+                reRequire('engines', engine);
+            }
+        }); %>
     });
 
 <% _.forEach(its, function(it) { %>

--- a/lib/techs/tmpl-spec.js
+++ b/lib/techs/tmpl-spec.js
@@ -78,16 +78,34 @@ module.exports = require('enb/lib/build-flow').create()
                     its: its,
                     engines: engines.map(function (engine) {
                         var target = contains(coverageEngines, engine.name) ?
-                            instrumentedTarget(engine.target) : engine.target;
+                            instrumentedTarget(engine.target) : engine.target,
+
+                            exportName = engine.exportName ? '.' + engine.exportName : '';
 
                         if (langs && !langs.length) {
                             target = target.replace('.js.instr.js', '.lang.js.instr.js');
                         }
 
+                        target = './' + node.unmaskTargetName(target);
+
+                        if (langs.length) {
+                            return {
+                                name: engine.name,
+                                langs: langs.map(function (lang) {
+                                    var langTarget = target.replace('.js', '.' + lang + '.js');
+                                    return {
+                                        name: lang,
+                                        target: langTarget,
+                                        exportName: exportName
+                                    };
+                                })
+                            };
+                        }
+
                         return {
                             name: engine.name,
-                            target: node.unmaskTargetName(target),
-                            exportName: engine.exportName
+                            target: target,
+                            exportName: exportName
                         };
                     }),
                     langs: langs,


### PR DESCRIPTION
Problem: some templates may define glabals, accessible from other
templates. In this case, global defined in one test can affect some
other test and break it.
This patch fixes the problem by re-requiring templates before each
test.

@blond, please review.