### PR TITLE
Don't skip istanbul's ignore flags

### DIFF
--- a/lib/coverage-object.js
+++ b/lib/coverage-object.js
@@ -9,44 +9,48 @@ module.exports = inherit({
         };
     },
 
-    addStatement: function (start, end, counter) {
-        var sourceName = start.source,
+    addStatement: function (statement, counter) {
+        var sourceName = statement.start.source,
             sourceObj = this._getFileObject(sourceName),
             idx = this._indices[sourceName].s++;
         sourceObj.statementMap[idx] = {
-            start: getLocation(start),
-            end: getLocation(end)
+            start: getLocation(statement.start),
+            end: getLocation(statement.end),
+            skip: statement.skip
         };
         sourceObj.s[idx] = counter;
     },
 
-    addFunction: function (name, start, end, counter) {
-        var sourceName = start.source,
+    addFunction: function (fn, counter) {
+        var sourceName = fn.start.source,
             sourceObj = this._getFileObject(sourceName),
             idx = this._indices[sourceName].f++;
         sourceObj.fnMap[idx] = {
-            name: name,
-            line: start.line,
+            name: fn.name,
+            line: fn.start.line,
+            skip: fn.skip,
             loc: {
-                start: getLocation(start),
-                end: getLocation(end)
+                start: getLocation(fn.start),
+                end: getLocation(fn.end),
+                skip: fn.skip
             }
         };
 
         sourceObj.f[idx] = counter;
     },
 
-    addBranch: function (type, locations, counter) {
-        var sourceName = locations[0].start.source,
+    addBranch: function (branch, counter) {
+        var sourceName = branch.locations[0].start.source,
             sourceObj = this._getFileObject(sourceName),
             idx = this._indices[sourceName].b++;
         sourceObj.branchMap[idx] = {
-            line: locations[0].start.line,
-            type: type,
-            locations: locations.map(function (loc) {
+            line: branch.locations[0].start.line,
+            type: branch.type,
+            locations: branch.locations.map(function (loc) {
                 return {
                     start: getLocation(loc.start),
-                    end: getLocation(loc.end)
+                    end: getLocation(loc.end),
+                    skip: loc.skip
                 };
             })
         };

--- a/lib/unmap-coverage.js
+++ b/lib/unmap-coverage.js
@@ -24,33 +24,39 @@ function unmapFile(fileName, fileObject, source) {
         result = new CoverageObject();
 
     Object.keys(fileObject.statementMap).forEach(function (key) {
-        var statement = fileObject.statementMap[key],
-            originalStart = locator.locate(statement.start.line, statement.start.column),
-            originalEnd = locator.locate(statement.end.line, statement.end.column);
-        result.addStatement(originalStart, originalEnd, fileObject.s[key]);
+        var statement = fileObject.statementMap[key];
+
+        result.addStatement({
+            start: locator.locate(statement.start.line, statement.start.column),
+            end: locator.locate(statement.end.line, statement.end.column),
+            skip: statement.skip
+        }, fileObject.s[key]);
     });
 
     Object.keys(fileObject.fnMap).forEach(function (key) {
         var fn = fileObject.fnMap[key],
-            loc = fn.loc,
-            originalStart = locator.locate(loc.start.line, loc.start.column),
-            originalEnd = locator.locate(loc.end.line, loc.end.column);
-        result.addFunction(fn.name, originalStart, originalEnd, fileObject.f[key]);
+            loc = fn.loc;
+        result.addFunction({
+            name: fn.name,
+            start: locator.locate(loc.start.line, loc.start.column),
+            end: locator.locate(loc.end.line, loc.end.column),
+            skip: fn.skip
+        }, fileObject.f[key]);
     });
 
     Object.keys(fileObject.branchMap).forEach(function (key) {
-        var branch = fileObject.branchMap[key],
-            locations = branch.locations.map(function (loc) {
+        var branch = fileObject.branchMap[key];
+        result.addBranch({
+            type: branch.type,
+            locations: branch.locations.map(function (loc) {
                 return {
                     start: locator.locate(loc.start.line, loc.start.column),
-                    end: locator.locate(loc.end.line, loc.end.column)
+                    end: locator.locate(loc.end.line, loc.end.column),
+                    skip: loc.skip
                 };
-            });
-        result.addBranch(
-            branch.type,
-            locations,
-            fileObject.b[key]
-        );
+            })
+
+        }, fileObject.b[key]);
     });
 
     return tryToStripSource(result.coverage, fileName);


### PR DESCRIPTION
Istanbul has ability to ignore certain statements, functions or
branches. This information is lost when we are splitting built file
coverage into sources. This patch restores `skip` flags.

Fix #73 