### PR TITLE
tmpl-specs targets fixed to use only blocks dir whithin entity fs tree. 

### DIFF
--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -22,7 +22,6 @@ var path = require('path'),
 
 exports.configure = function (config, options) {
     var pattern = path.join(options.destPath, '*'),
-        sourceLevels = [].concat(options.sourceLevels, options.sublevels),
         coverageRe = new RegExp('/' + options.coverage.completeBundle + '$');
 
     config.nodes(pattern, function (nodeConfig) {
@@ -30,7 +29,9 @@ exports.configure = function (config, options) {
             engines = options.engines,
             coverageEngines = options.coverage.engines,
             engineTargets = [],
-            isCoverageBundle = coverageRe.test(nodeConfig.getPath());
+            nodePath = nodeConfig.getPath(),
+            isCoverageBundle = coverageRe.test(nodePath),
+            sourceLevels = [].concat(options.sourceLevels, options.sublevels[nodePath] || []);
 
         // Base techs
         nodeConfig.addTechs([

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -108,17 +108,11 @@ module.exports = function (helper) {
                     completeBundleDirname && vfs.makeDir(path.join(options.root, completeBundleDirname)),
                     scanner.scan(options.levels)
                         .then(function (files) {
-                            var sublevels = [],
+                            var sublevels = {},
                                 nodes = {},
                                 nodesToRun = {};
 
                             files.forEach(function (file) {
-                                file.files && file.files.forEach(function (dir) {
-                                    if (dir.isDirectory && dir.name === 'blocks') {
-                                        sublevels.push(dir.fullname);
-                                    }
-                                });
-
                                 if (options.referenceDirSuffixes.indexOf(file.suffix) !== -1) {
                                     var bemname = file.name.split('.')[0],
                                         node = path.join(options.destPath, bemname),
@@ -130,6 +124,12 @@ module.exports = function (helper) {
 
                                         magic.isRequiredTarget(mainTarget) && (nodesToRun[node] = true);
                                     }
+
+                                    file.files && file.files.forEach(function (dir) {
+                                        if (dir.isDirectory && dir.name === 'blocks') {
+                                            (sublevels[node] || (sublevels[node] = [])).push(dir.fullname);
+                                        }
+                                    });
                                 }
                             });
 


### PR DESCRIPTION
All tmpl-specs targets were using the same `sublevels` array containing all `blocks` dirs found on the levels. Fixed to use only blocks dir whithin entity fs tree. 