### PR TITLE
Support native mocha reporters

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -5,7 +5,7 @@ var path = require('path'),
     _ = require('lodash'),
     scanner = require('enb-bem-pseudo-levels/lib/level-scanner'),
     configurator = require('./node-configurator'),
-    runner = require('./runner'),
+    Runner = require('./runner'),
     XJST_PACKAGES = ['enb-xjst', 'enb-bemhtml', 'enb-bemxjst'],
     XJST_EXPORT_NAME = 'BEMHTML';
 
@@ -14,6 +14,7 @@ module.exports = function (helper) {
         configure: function (options) {
             var initedOptions = this._init(options);
 
+            this._runner = new Runner(initedOptions);
             this._buildTargets(initedOptions);
             this._configureNodes(initedOptions);
             this._runSpecs(initedOptions);
@@ -191,6 +192,8 @@ module.exports = function (helper) {
         },
 
         _runSpecs: function (options) {
+            var runner = this._runner;
+
             helper._projectConfig.task(helper.getTaskName(), function () {
                 var filesToRun = options.nodesToRun.map(function (node) {
                     var basename = path.basename(node);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -36,8 +36,10 @@ exports.run = function (files, opts) {
 
 // Helper allow you to run the multiple reporters
 function runReporters(diffOpts) {
+    var reporters = getReporters();
+
     return function (runner) {
-        getReporters().forEach(function (Reporter) {
+        reporters.forEach(function (Reporter) {
             Reporter && new Reporter(runner, diffOpts);
         });
     };
@@ -50,17 +52,13 @@ function getReporters() {
     reporters = reporters
         .split(',')
         .map(function (reporter) {
-            try {
-                return require('./reporters/' + reporter);
-            } catch (e) {
-                if (e.code === 'MODULE_NOT_FOUND') {
-                    throw new Error(
-                        'Reporter (' + reporter + ') specified through ' +
-                        'the "Environment Variables" was not found!'
-                    );
-                }
-                throw e;
-            }
+            var mock = { options: {} },
+                _reporter;
+
+            try { _reporter = require('./reporters/' + reporter); } catch (err) {}
+            if (!_reporter) _reporter = Mocha.prototype.reporter.apply(mock, [reporter])._reporter;
+
+            return _reporter;
         });
 
     return reporters;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,13 +6,19 @@ var vow = require('vow'),
 
     unmapCoverageObject = require('./unmap-coverage');
 
-exports.run = function (files, opts) {
+function Runner(opts) {
+    this._opts = opts;
+    this._mocha = new Mocha({
+        ui: 'bdd',
+        reporter: runReporters(opts.diffOpts),
+        grep: parseRe(opts.grep)
+    });
+}
+
+Runner.prototype.run = function (files) {
     var defer = vow.defer(),
-        mocha = new Mocha({
-            ui: 'bdd',
-            reporter: runReporters(opts.diffOpts),
-            grep: parseRe(opts.grep)
-        });
+        mocha = this._mocha,
+        opts = this._opts;
 
     mocha.files = files;
     mocha.run(function (failures) {
@@ -33,6 +39,8 @@ exports.run = function (files, opts) {
 
     return defer.promise();
 };
+
+module.exports = Runner;
 
 // Helper allow you to run the multiple reporters
 function runReporters(diffOpts) {


### PR DESCRIPTION
Resolved #38 

Need use `BEM_TMPL_SPECS_REPORTERS` environment variable.

Run examples with `dot` reporter:

```
BEM_TMPL_SPECS_REPORTERS=dot enb -d examples/silly make tmpl-specs
```

![2015-06-20 18 19 47](https://cloud.githubusercontent.com/assets/2225579/8267874/0a578e5c-1779-11e5-9361-d2d4deb564c3.png)

If reporter is not found program exit before build:

![2015-06-20 18 24 07](https://cloud.githubusercontent.com/assets/2225579/8267888/8f7d2f7e-1779-11e5-96fc-0cf1be872459.png)
