### PR TITLE
Вставлять mock для BEM.I18N до контента шаблона

### DIFF
--- a/lib/techs/mock-lang-js.js
+++ b/lib/techs/mock-lang-js.js
@@ -34,7 +34,7 @@ module.exports = require('enb/lib/build-flow').create()
                     content = content.substring(0, mapIndex);
                 }
 
-                return [content, mock, map].join('\n');
+                return [mock, content, map].join('\n');
             });
     })
     .createTech();


### PR DESCRIPTION
Привет. 
В [BH](https://github.com/bem/bh) с версии `4.x.x` больше нет прямой связи с `BEM.I18N`. Теперь если есть желание работать с переводами в BH нужно сделать: `bh.lib.i18n = BEM.I18N`.

При текущей реализации `mock-lang-js.js` сделать это не получается, так как `BEM.I18N` объявлен позже. Я перенес его в место перед кодом шаблонов. 