### PR TITLE
Fixed `mock-lang-js` tech

### DIFF
--- a/lib/techs/mock-lang-js.js
+++ b/lib/techs/mock-lang-js.js
@@ -1,13 +1,17 @@
-var vfs = require('enb/lib/fs/async-fs');
+var vfs = require('enb/lib/fs/async-fs'),
+    File = require('enb-source-map/lib/file'),
+    EOL = require('os').EOL;
 
 module.exports = require('enb/lib/build-flow').create()
     .name('mock-lang-js.js')
     .target('target', '?.js')
     .useSourceFilename('source', '?.lang.js')
-    .builder(function (source) {
-        return vfs.read(source, 'utf8')
-            .then(function (content) {
-                var mock = [
+    .builder(function (sourceFilename) {
+        return vfs.read(sourceFilename, 'utf8')
+            .then(function (contents) {
+                var withSourceMaps = true,
+                    file = new File(this._target, withSourceMaps),
+                    mock = [
                         ';(function(global, bem_) {',
                         '    global.BEM = bem_;',
                         '    var i18n = bem_.I18N = function(keyset, key, param) {',
@@ -21,20 +25,12 @@ module.exports = require('enb/lib/build-flow').create()
                         '    i18n.key = function(key) { return key }',
                         '    i18n.lang = function() { return }',
                         '}(this, typeof BEM === \'undefined\' ? {} : BEM));'
-                    ].join('\n'),
-                    mapIndex = content.lastIndexOf('//# sourceMappingURL='),
-                    map;
+                    ].join(EOL);
 
-                // if there is a #sourceMappingURL pragma append
-                // the mock before it so the source map will be
-                // valid. We can't insert it in the beginning because
-                // source map locations will point to the wrong lines.
-                if (mapIndex !== -1) {
-                    map = content.substring(mapIndex);
-                    content = content.substring(0, mapIndex);
-                }
+                file.write(mock);
+                file.writeFileContent(sourceFilename, contents);
 
-                return [content, mock, map].join('\n');
+                return file.render();
             });
     })
     .createTech();


### PR DESCRIPTION
Resolved #94 

* Used `enb-source-map` to concat files
* Supported BH@4.x with BEM.I18N