### PR TITLE
Оптимизировал процесс подсчета coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,74 @@
 История изменений
 =================
 
+1.0.0
+-----
+
+### API
+
+* [ __*major*__ ] Опции `coverage`, `htmlDiffer`, `grep` задаются для [всех уровней-сетов](./README.md#Как-использовать) и не могут быть переопределены при конфигурации определенного уровня-сета.
+* [ __*major*__ ] Поле `completeBundle` вынесено из опции `coverage` в отдельную опцию, которая может быть задана для каждого уровня-сета в отдельности.
+
+**Было:**
+
+```js
+// ...
+
+    var examples = config.module('enb-bem-tmpl-specs')
+        .createConfigurator('tmpl-specs');
+
+    examples.configure({
+        // ...
+
+        coverage: {
+            engines: ['bh'],
+            reportDirectory: 'coverage',
+            exclude: ['**/node_modules/**', '**/libs/**'],
+            reporters: ['lcov'],
+            completeBundle: ''
+        },
+        htmlDiffer: { preset: 'bem' },
+        grep: '*'
+
+        // ...
+    });
+
+// ...
+```
+
+**Стало:**
+
+```js
+// ...
+
+    var examples = config.module('enb-bem-tmpl-specs')
+        .createConfigurator('tmpl-specs', {
+            coverage: {
+                engines: ['bh'],
+                reportDirectory: 'coverage',
+                exclude: ['**/node_modules/**', '**/libs/**'],
+                reporters: ['lcov']
+            },
+            htmlDiffer: { preset: 'bem' },
+            grep: '*'
+        });
+
+    examples.configure({
+        // ...
+
+        compleBundle: ''
+
+        // ...
+    });
+
+// ...
+```
+
+### Исправления ошибок
+
+* Оптимизировали подсчет информации о покрытии кода тестами ([#120]), что позволило снизить нагрузку на потребление оперативной памяти.
+* При падении тестов в одном из уровней-сетов тесты остальных не запускались.
+
 0.16.0
 ------
 
@@ -283,6 +351,7 @@
 
 * Добавлены `summary` и `html` отчёты.
 
+[#120]: https://github.com/enb-bem/enb-bem-tmpl-specs/pull/120
 [#117]: https://github.com/enb-bem/enb-bem-tmpl-specs/pull/117
 [#110]: https://github.com/enb-bem/enb-bem-tmpl-specs/issues/110
 [#109]: https://github.com/enb-bem/enb-bem-tmpl-specs/issues/109

--- a/README.md
+++ b/README.md
@@ -5,6 +5,27 @@ enb-bem-tmpl-specs
 
 Инструмент для сборки и запуска тестов на шаблоны. В процессе сборки генерируются сеты из бандлов с тестами на шаблоны БЭМ-блоков с помощью [ENB](http://enb-make.info/).
 
+<!-- TOC -->
+- [Установка](#Установка)
+- [Как создать тест?](#Как-создать-тест)
+- [Результат сборки](#Результат-сборки)
+- [Поддержка шаблонизаторов](#Поддержка-шаблонизаторов)
+- [Запуск тестов](#Запуск-тестов)
+- [Вывод ошибок](#Вывод-ошибок)
+- [Формат вывода ошибок](#Формат-вывода-ошибок)
+- [Сохранение результатов](#Сохранение-результатов)
+- [Фильтрация тестов](#Фильтрация-тестов)
+  - [Доступные форматы отчетов](#Доступные-форматы-отчетов)
+- [Как использовать?](#Как-использовать)
+  - [Опции для всех уровней-сетов](#Опции-для-всех-уровней-сетов)
+  - [Опции для определенного уровня-сета](#Опции-для-определенного-уровня-сета)
+- [Запуск из консоли](#Запуск-из-консоли)
+  - [Сборка и запуск всех тестов на шаблоны](#Сборка-и-запуск-всех-тестов-на-шаблоны)
+  - [Сборка всех тестов на шаблоны для указанной БЭМ-сущности](#Сборка-всех-тестов-на-шаблоны-для-указанной-БЭМ-сущности)
+- [Лицензия](#Лицензия)
+
+<!-- TOC END -->
+
 Установка
 ---------
 
@@ -140,7 +161,14 @@ module.exports = function (config) {
     config.includeConfig('enb-bem-tmpl-specs'); // Подключаем `enb-bem-tmpl-specs` модуль.
 
     var examples = config.module('enb-bem-tmpl-specs') // Создаём конфигуратор сетов
-        .createConfigurator('tmpl-specs');             //  в рамках таска `specs`.
+        .createConfigurator('tmpl-specs', {            // в рамках таска `specs`.
+            coverage: {                                // Определяем общие опции для всех уровней-сетов.
+                engines: ['bh'],
+                reportDirectory: 'coverage',
+                exclude: ['**/node_modules/**', '**/libs/**'],
+                reporters: ['lcov']
+            }
+        });
 
     examples.configure({
         destPath: 'desktop.tmpl-specs',
@@ -177,7 +205,17 @@ module.exports = function (config) {
 };
 ```
 
-### Опции
+### Опции для всех уровней-сетов
+
+* *Object* `coverage` – собирать информацию о покрытии кода тестами.
+  - *String[]* `engines` – список шаблонизаторов, которые необходимо учитывать при формировании отчета;
+  - *String* `reportDirectory` – название папки, в которой необходимо создать отчет. По умолчанию – `coverage`;
+  - *String[]* `exclude` – маски путей, которые необходимо исключить при формировании отчета. По&nbsp;умолчанию&nbsp;&mdash;&nbsp;`['**/node_modules/**', '**/libs/**']`;
+  - *String[]* `reporters` – форматы отчетов (env: `BEM_TMPL_SPECS_COV_REPORTERS`, названия форматов отчётов передаются через запятую), см.&nbsp;[istanbul#report](https://github.com/gotwarlost/istanbul/tree/master/lib/report). По умолчанию – `['lcov']`.
+* *Object* `htmlDiffer` — настройки сравнения HTML при помощи [html-differ](https://ru.bem.info/tools/testing/html-differ/). По&nbsp;умолчанию&nbsp;&mdash;&nbsp;`{ preset: 'bem' }`.
+* *String|RegExp* `grep` — фильтр тестов по названию (env: `BEM_TMPL_SPECS_GREP`), см. [mocha#grep](http://mochajs.org/#grep-option).
+
+### Опции для определенного уровня-сета
 
 * *String* `destPath` &mdash;&nbsp;путь относительно корня до&nbsp;нового уровня-сета с&nbsp;тестами на шаблоны, которые нужно собрать. Обязательная опция.
 * *String[] | Object[]* `levels` &mdash;&nbsp;уровни, в&nbsp;которых следует искать эталоны. Обязательная опция.
@@ -189,9 +227,8 @@ module.exports = function (config) {
   - *String* `tech` — путь к ENB-технологии;
   - *Object* `options` — опции для ENB-технологии;
   - *Boolean* `async` — асинхронный шаблонизатор;
+* *String* `completeBundle` – имя бандла, в котором будут собраны все БЭМ-сущности из уровней `levels`. По умолчанию `completeBundle` не будет собран.
 * *Boolean* `saveHtml` — сохранять результат html при успешной отрисовке в файл (env: `BEM_TMPL_SPECT_SAVE_HTML`);
-* *String|RegExp* `grep` — фильтр тестов по названию (env: `BEM_TMPL_SPECS_GREP`), см. [mocha#grep](http://mochajs.org/#grep-option).
-* *Object* `htmlDiffer` — настройки сравнения HTML при помощи [html-differ](https://ru.bem.info/tools/testing/html-differ/). По&nbsp;умолчанию&nbsp;&mdash;&nbsp;`{ preset: 'bem' }`.
 * *String|Function* `depsTech` — технология для раскрытия зависимостей. По умолчанию — `deps-old`.
 * *Function* `mockI18N` — функция будет использована вместо ядра `i18n`, если указана опция `langs: true`.
 

--- a/examples/silly/.enb/make.js
+++ b/examples/silly/.enb/make.js
@@ -21,7 +21,13 @@ module.exports = function (config) {
     config.includeConfig(rootPath);
 
     var module = config.module('enb-bem-tmpl-specs'),
-        helper = module.createConfigurator('tmpl-specs');
+        helperWithCoverage = module.createConfigurator('tmpl-specs-with-coverage', {
+            coverage: {
+                engines: ['BH'],
+                exclude: ['**/*.tmpl-specs/**', '**/node_modules/**']
+            }
+        }),
+        helperWithoutCoverage = module.createConfigurator('tmpl-specs-without-coverage');
 
     declareSpec('no lang', {
         langs: false,
@@ -84,7 +90,7 @@ module.exports = function (config) {
 
         opts.destPath = destPath;
 
-        helper.configure(_.assign({}, {
+        (opts.coverage ? helperWithCoverage : helperWithoutCoverage).configure(_.assign({}, {
             engines: {
                 'BH': opts.langs ? _.assign({}, engines.bh, {
                     options: { requires: { i18n: { globals: 'BEM.I18N' } } }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,10 @@ function TmplSpecSets(config) {
     config.includeConfig(require.resolve('enb-magic-factory'));
 }
 
-TmplSpecSets.prototype.createConfigurator = function (taskName) {
+TmplSpecSets.prototype.createConfigurator = function (taskName, options) {
     var factory = this._config.module('enb-magic-factory');
 
-    return plugin(factory.createHelper(taskName));
+    return plugin(factory.createHelper(taskName), options);
 };
 
 module.exports = function (config) {

--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -23,7 +23,7 @@ var path = require('path'),
 
 exports.configure = function (config, options) {
     var pattern = path.join(options.destPath, '*'),
-        coverageRe = new RegExp('/' + options.coverage.completeBundle + '$'),
+        coverageRe = new RegExp('/' + options.completeBundle + '$'),
         depsTech;
 
     if (typeof options.depsTech === 'function') {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -10,34 +10,54 @@ var path = require('path'),
     XJST_PACKAGES = ['enb-xjst', 'enb-bemhtml', 'enb-bemxjst'],
     XJST_EXPORT_NAME = 'BEMHTML';
 
-module.exports = function (helper) {
+module.exports = function (helper, commonOpts) {
+    commonOpts = initCommonOpts(commonOpts);
+
+    var needCoverage = Boolean(commonOpts.coverage),
+        root = helper.getRootPath(),
+        runner = new Runner(commonOpts),
+        defer = vow.defer();
+
+    // Подобное доопределение таска необходимо, чтобы он гарантировано выполнился до завершения всей сборки
+    helper._projectConfig.task(helper.getTaskName(), function () { return defer.promise(); });
+
+    helper.getEventChannel().on('build', function () {
+        var filesToRun = helper._nodesToRun.map(function (node) {
+            var basename = path.basename(node);
+
+            return path.join(root, node, basename + '.tmpl-spec.js');
+        });
+
+        if (!filesToRun.length || helper.getMode() === 'pre') { // В `pre` режиме magic-нод запускаем тесты
+            return defer.resolve();                             // только для таргета `?.tmpl-specs.js`
+        }
+
+        return runner.run(filesToRun, { needCoverage: needCoverage })
+            .then(defer.resolve.bind(defer))
+            .fail(defer.reject.bind(defer));
+    });
+
     return {
         configure: function (options) {
             var initedOptions = this._init(options);
 
-            this._runner = new Runner(initedOptions);
             this._buildTargets(initedOptions);
             this._configureNodes(initedOptions);
-            this._runSpecs(initedOptions);
         },
 
         _init: function (options) {
-            var root = helper.getRootPath(),
-                engines = options.engines,
-                coverage = options.coverage || {},
-                diffOpts = options.htmlDiffer || {};
+            var engines = options.engines,
+                enginesNames = Object.keys(engines),
+                coverage = {};
 
-            diffOpts.preset || (diffOpts.preset = 'bem');
+            if (needCoverage) {
+                var coverageEngines = commonOpts.coverage.engines;
 
-            if (coverage === true) {
-                coverage = {
-                    engines: Object.keys(engines)
-                };
+                coverage.engines = coverageEngines ? _.intersection(coverageEngines, enginesNames) : enginesNames;
             }
 
             return {
                 _options: options,
-                root: root,
                 destPath: options.destPath,
                 levels: options.levels.map(function (levelPath) {
                     var level = (typeof levelPath === 'string') ? { path: levelPath } : levelPath;
@@ -74,42 +94,30 @@ module.exports = function (helper) {
                 }),
                 sourceLevels: options.sourceLevels || options.levels,
                 coverage: _.defaults(coverage, {
-                    engines: [],
-                    reportDirectory: 'coverage',
-                    exclude: [
-                        '**/node_modules/**',
-                        '**/libs/**'
-                    ],
-                    reporters: process.env.BEM_TMPL_SPECS_COV_REPORTERS ?
-                        process.env.BEM_TMPL_SPECS_COV_REPORTERS.split(',')
-                        : ['lcov'],
-                    completeBundle: ''
+                    engines: []
                 }),
+                completeBundle: options.completeBundle || '',
                 referenceDirSuffixes: options.referenceDirSuffixes || ['tmpl-specs'],
                 saveHtml: (typeof process.env.BEM_TMPL_SPECS_SAVE_HTML === 'undefined' ?
                     options.saveHtml :
                     process.env.BEM_TMPL_SPECS_SAVE_HTML) || false,
-                grep: (typeof process.env.BEM_TMPL_SPECS_GREP === 'undefined' ?
-                    options.grep :
-                    process.env.BEM_TMPL_SPECS_GREP) || false,
-                diffOpts: diffOpts,
                 depsTech: options.depsTech
             };
         },
 
         _buildTargets: function (options) {
             var _this = this,
-                dstpath = path.resolve(options.root, options.destPath);
+                dstpath = path.resolve(root, options.destPath);
 
             helper.prebuild(function (magic) {
                 var completeBundleDirname;
-                if (options.coverage.engines.length && options.coverage.completeBundle) {
-                    completeBundleDirname = path.join(options.destPath, options.coverage.completeBundle);
+                if (needCoverage && options.completeBundle) {
+                    completeBundleDirname = path.join(options.destPath, options.completeBundle);
                     magic.registerNode(completeBundleDirname);
                 }
 
                 return vow.all([
-                    completeBundleDirname && vfs.makeDir(path.join(options.root, completeBundleDirname)),
+                    completeBundleDirname && vfs.makeDir(path.join(root, completeBundleDirname)),
                     scanner.scan(options.levels)
                         .then(function (files) {
                             var sublevels = {},
@@ -140,13 +148,15 @@ module.exports = function (helper) {
                             options.sublevels = sublevels;
                             options.nodes = Object.keys(nodes);
 
-                            var completeBundleNode = path.join(options.destPath, options.coverage.completeBundle);
-                            options.nodesToRun = Object.keys(nodesToRun)
-                                .concat(
+                            var completeBundleNode = path.join(options.destPath, options.completeBundle);
+
+                            helper._nodesToRun = (helper._nodesToRun || []).concat(
+                                Object.keys(nodesToRun).concat(
                                     (completeBundleDirname && magic.isRequiredNode(completeBundleNode)) ?
                                         completeBundleNode :
                                         []
-                                );
+                                )
+                            );
 
                             return vow.all(options.nodes.map(function (node) {
                                 return _this._buildBemdecl(dstpath, node);
@@ -168,8 +178,9 @@ module.exports = function (helper) {
                     saveHtml: options.saveHtml,
                     coverage: options.coverage,
                     sublevels: options.sublevels,
-                    diffOpts: options.diffOpts,
-                    depsTech: options.depsTech
+                    depsTech: options.depsTech,
+                    completeBundle: options.completeBundle,
+                    diffOpts: commonOpts.diffOpts,
                 });
             });
         },
@@ -195,25 +206,26 @@ module.exports = function (helper) {
                 .then(function () {
                     return vfs.write(bemdeclFilename, bemdeclSource, 'utf-8');
                 });
-        },
-
-        _runSpecs: function (options) {
-            var runner = this._runner;
-
-            helper._projectConfig.task(helper.getTaskName(), function () {
-                var filesToRun = options.nodesToRun.map(function (node) {
-                    var basename = path.basename(node);
-
-                    return path.join(options.root, node, basename + '.tmpl-spec.js');
-                });
-
-                // В `pre` режиме magic-нод запускаем тесты только для таргета `?.tmpl-specs.js`
-                if (helper.getMode() === 'pre' && filesToRun.length > 1) {
-                    return;
-                }
-
-                return filesToRun.length && runner.run(filesToRun, options);
-            });
         }
     };
 };
+
+function initCommonOpts(opts) {
+    opts || (opts = {});
+
+    var covReporters = process.env.BEM_TMPL_SPECS_COV_REPORTERS,
+        grep = process.env.BEM_TMPL_SPECS_GREP;
+
+    return {
+        coverage: opts.coverage && _.defaults(opts.coverage === true ? {} : opts.coverage, {
+            reportDirectory: 'coverage',
+            exclude: [
+                '**/node_modules/**',
+                '**/libs/**'
+            ],
+            reporters: covReporters ? covReporters.split(',') : ['lcov']
+        }),
+        grep: (typeof grep === 'undefined' ? opts.grep : grep) || false,
+        diffOpts: _.defaults(opts.htmlDiffer || {}, { preset: 'bem' })
+    };
+}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -15,7 +15,9 @@ function Runner(opts) {
     });
 }
 
-Runner.prototype.run = function (files) {
+Runner.prototype.run = function (files, params) {
+    params || (params = {});
+
     var defer = vow.defer(),
         mocha = this._mocha,
         opts = this._opts;
@@ -26,7 +28,7 @@ Runner.prototype.run = function (files) {
             failures ? defer.reject(new Error('tmpl-specs: ' + failures + ' failing')) : defer.resolve();
         }
 
-        if (opts.coverage.engines.length > 0) {
+        if (params.needCoverage) {
             processCoverage(opts.coverage)
                 .then(resolvePromise)
                 .fail(function (err) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test": "npm run lint && npm run clean && npm run build",
     "lint": "jshint . && jscs -c .jscs.js .",
     "deps": "cd examples && bower i",
-    "build": "enb -d examples/silly make tmpl-specs",
+    "build": "enb -d examples/silly make tmpl-specs-with-coverage && enb -d examples/silly make tmpl-specs-without-coverage",
     "clean": "rm -rf examples/*/*tmpl-specs && rm -rf examples/*/.enb/tmp && rm -rf coverage"
   }
 }


### PR DESCRIPTION
#### Описание

В текущей реализации `coverage` считается каждый раз после запуска тестов в определенном бандле, то есть после запуска тестов на `desktop` считается `coverage` для `desktop`, после запуска тестов на `touch-pad` считается `coverage` для `desktop` и `touch-pad` (хотя ранее уже был посчитан `coverage` для `desktop`), после запуска тестов на `touch-phone` считается `coverage` для `desktop`, `touch-pad` и `touch-phone` и т. д.

#### Решение

Запускать все тесты и подсчет `coverage` один раз, после сборки всех бандлов с тестами.

#### Тесты

Протестировал интеграционно

#### Важно

Ломает обратную совместимость!

#### Ревью

/cc @blond 